### PR TITLE
Remove signing terminology

### DIFF
--- a/draft-sullivan-cfrg-oprf.md
+++ b/draft-sullivan-cfrg-oprf.md
@@ -328,7 +328,7 @@ This public key is also referred to as a commitment to the key k. Let x be the
 verifier's (V) input to the OPRF protocol. (Commonly, it is a random L-bit
 string, though this is not required.)
 
-The OPRF protocol begins with V blinding its input for the signer such that it
+The OPRF protocol begins with V blinding its input for the OPRF evaluator such that it
 appears uniformly distributed GG. The latter then applies its secret key to the
 blinded value and returns the result. To finish the computation, V then removes
 its blind and hashes the result using H_2 to yield an output. This flow is
@@ -374,22 +374,22 @@ This protocol may be decomposed into a series of steps, as described below:
 - OPRF_Setup(l): Generate am integer k of sufficient bit-length l and output k.
 - OPRF_Blind(x): Compute and return a blind, r, and blinded representation of x
   in GG, denoted M.
-- OPRF_Sign(k,M,h): Sign input M using secret key k to produce Z, the input h is
-  optional and equal to the cofactor of an elliptic curve. If h is not provided
-  then it defaults to 1.
-- OPRF_Unblind(r,Z): Unblind blinded signature Z with blind r, yielding N and
+- OPRF_Eval(k,M,h?): Evaluest on input M using secret key k to produce Z, the
+  input h is optional and equal to the cofactor of an elliptic curve. If h is
+  not provided then it defaults to 1.
+- OPRF_Unblind(r,Z): Unblind blinded OPRF evaluation Z with blind r, yielding N and
   output N.
 - OPRF_Finalize(x,N): Finalize N to produce the output H_2(x, N).
 
-For verifiability we modify the algorithms of VOPRF_Setup, VOPRF_Sign and
+For verifiability we modify the algorithms of VOPRF_Setup, VOPRF_Eval and
 VOPRF_Unblind to be the following:
 
 - VOPRF_Setup(l): Generate an integer k of sufficient bit-length l and output
   (k, (G,Y)) where Y = kG for some generator G in GG.
-- VOPRF_Sign(k,(G,Y),M,h): Sign input M using secret key k to produce Z. Generate
-  a NIZK proof D = DLEQ_Generate(k,G,Y,M,Z), and output (Z, D). The optional
-  cofactor h can also be provided as in OPRF_Sign.
-- VOPRF_Unblind(r,G,Y,M,(Z,D)): Unblind blinded signature Z with blind r,
+- VOPRF_Eval(k,(G,Y),M,h?): Evaluest on input M using secret key k to produce Z.
+  Generate a NIZK proof D = DLEQ_Generate(k,G,Y,M,Z), and output (Z, D). The
+  optional cofactor h can also be provided, as in OPRF_Eval.
+- VOPRF_Unblind(r,G,Y,M,(Z,D)): Unblind blinded OPRF evaluation Z with blind r,
   yielding N. Output N if 1 = DLEQ_Verify(G,Y,M,Z,D). Otherwise, output "error".
 
 We leave the rest of the OPRF algorithms unmodified. When referring explicitly
@@ -401,14 +401,14 @@ Protocol correctness requires that, for any key k, input x, and (r, M) =
 OPRF_Blind(x), it must be true that:
 
 ~~~
-OPRF_Finalize(x, OPRF_Unblind(r,M,OPRF_Sign(k,M))) = H_2(x, F(k,x))
+OPRF_Finalize(x, OPRF_Unblind(r,M,OPRF_Eval(k,M))) = H_2(x, F(k,x))
 ~~~
 
 with overwhelming probability. Likewise, in the verifiable setting, we require
 that:
 
 ~~~
-VOPRF_Finalize(x, VOPRF_Unblind(r,(G,Y),M,(VOPRF_Sign(k,(G,Y),M)))) = H_2(x, F(k,x))
+VOPRF_Finalize(x, VOPRF_Unblind(r,(G,Y),M,(VOPRF_Eval(k,(G,Y),M)))) = H_2(x, F(k,x))
 ~~~
 
 with overwhelming probability, where (r, M) = VOPRF_Blind(x).
@@ -491,12 +491,12 @@ Steps:
  3.  Output (r, M)
 ~~~
 
-### OPRF_Sign
+### OPRF_Eval
 
 ~~~
 Input:
 
- k: Signer secret key.
+ k: Evaluator secret key.
  M: An element in GG.
  h: optional cofactor (defaults to 1).
 
@@ -521,7 +521,7 @@ Input:
 
 Output:
 
- N: Unblinded signature, element in GG.
+ N: Unblinded OPRF evaluation, element in GG.
 
 Steps:
 
@@ -603,14 +603,14 @@ Steps:
  3.  Output (r, M)
 ~~~
 
-### VOPRF_Sign
+### VOPRF_Eval
 
 ~~~
 Input:
 
- k: Signer secret key.
+ k: Evaluator secret key.
  G: Public generator of group GG.
- Y: Signer public key (= kG).
+ Y: Evaluator public key (= kG).
  M: An element in GG.
  h: optional cofactor (defaults to 1).
 
@@ -634,14 +634,14 @@ Input:
 
  r: Random scalar in [1, p - 1].
  G: Public generator of group GG.
- Y: Signer public key.
+ Y: Evaluator public key.
  M: Blinded representation of x using blind r, an element in GG.
  Z: An element in GG.
  D: D = DLEQ_Generate(k,G,Y,M,Z).
 
 Output:
 
- N: Unblinded signature, element in GG.
+ N: Unblinded OPRF evaluation, element in GG.
 
 Steps:
 
@@ -763,7 +763,7 @@ Input:
 
 Output:
 
- N: Unblinded signature, element in GG.
+ N: Unblinded OPRF evaluation, element in GG.
 
 Steps:
 
@@ -780,7 +780,7 @@ original OPRF_Unblind algorithm.
 For the VOPRF protocol we require that V is able to verify that P has used its
 private key k to evaluate the PRF. We can do this by showing that the original
 commitment (G,Y) output by VOPRF_Setup(l) satisfies log_G(Y) == log_M(Z) where Z
-is the output of VOPRF_Sign(k,(G,Y),M).
+is the output of VOPRF_Eval(k,(G,Y),M).
 
 This may be used, for example, to ensure that P uses the same private key for
 computing the VOPRF output and does not attempt to "tag" individual verifiers
@@ -796,9 +796,9 @@ DLEQ_Generate and DLEQ_Verify. These are specified below.
 ~~~
 Input:
 
- k: Signer secret key.
+ k: Evaluator secret key.
  G: Public generator of GG.
- Y: Signer public key (= kG).
+ Y: Evaluator public key (= kG).
  M: An element in GG.
  Z: An element in GG.
  H_3: A hash function from GG to {0,1}^L, modelled as a random oracle.
@@ -822,7 +822,7 @@ Steps:
 Input:
 
  G: Public generator of GG.
- Y: Signer public key.
+ Y: Evaluator public key.
  M: An element in GG.
  Z: An element in GG.
  D: DLEQ proof (c, s).
@@ -870,9 +870,9 @@ as input, and outputs n elements in {0,1}^b.
 ~~~
 Input:
 
- k: Signer secret key.
+ k: Evaluator secret key.
  G: Public generator of group GG.
- Y: Signer public key (= kG).
+ Y: Evaluator public key (= kG).
  n: Number of PRF evaluations.
  [Mi]: An array of points in GG of length n.
  [Zi]: An array of points in GG of length n.
@@ -901,7 +901,7 @@ Steps:
 Input:
 
  G: Public generator of group GG.
- Y: Signer public key.
+ Y: Evaluator public key.
  [Mi]: An array of points in GG of length n.
  [Zi]: An array of points in GG of length n.
  D: DLEQ proof (c, s).
@@ -925,7 +925,7 @@ Steps:
 The VOPRF protocol from Section {{protocol}} changes to allow specifying
 multiple blinded PRF inputs [Mi] for i in 1...n. Then P computes the array [Zi]
 and replaces DLEQ_Generate with Batched_DLEQ_Generate over these arrays. The
-same applies to the algorithm VOPRF_Sign. The same applies for replacing
+same applies to the algorithm VOPRF_Eval. The same applies for replacing
 DLEQ_Verify with Batched_DLEQ_Verify when V verifies the response from P and
 during the algorithm VOPRF_Verify.
 
@@ -1016,7 +1016,7 @@ For this side effect to hold, P must also be prevented from using other
 techniques to manipulate their public key within the trusted registry to
 reduce client anonymity. For example, if P's public key is rotated too
 frequently then this may stratify the user base into small anonymity groups
-(those with VOPRF_Sign outputs taken from a given key epoch). In this case,
+(those with VOPRF_Eval outputs taken from a given key epoch). In this case,
 it may become practical to link VOPRF sessions for a given user and thus
 compromises their privacy.
 
@@ -1034,10 +1034,10 @@ This VOPRF protocol is used by Privacy Pass system to help Tor users bypass
 CAPTCHA challenges. Their system works as follows. Client C connects -- through
 Tor -- to an edge server E serving content. Upon receipt, E serves a CAPTCHA to
 C, who then solves the CAPTCHA and supplies, in response, n blinded points. E
-verifies the CAPTCHA response and, if valid, signs (at most) n blinded points,
+verifies the CAPTCHA response and, if valid, evaluates the OPRF on (at most) n blinded points,
 which are then returned to C along with a batched DLEQ proof. C stores the
 tokens if the batched proof verifies correctly. When C attempts to connect to E
-again and is prompted with a CAPTCHA, C uses one of the unblinded and signed
+again and is prompted with a CAPTCHA, C uses one of the unblinded and OPRF evaluated
 points, or tokens, to derive a shared symmetric key sk used to MAC the CAPTCHA
 challenge. C sends the CAPTCHA, MAC, and token input x to E, who can use x to
 derive sk and verify the CAPTCHA MAC. Thus, each token is used at most once by
@@ -1049,11 +1049,11 @@ protocol. For more details, see {{DGSTV18}}.
 ## Private Password Checker
 
 In this application, let D be a collection of plaintext passwords obtained by
-prover P. For each password p in D, P computes VOPRF_Sign on H_1(p), where H_1
+prover P. For each password p in D, P computes VOPRF_Eval on H_1(p), where H_1
 is as described above, and stores the result in a separate collection D'. P then
 publishes D' with Y, its public key. If a client C wishes to query D' for a
 password p', it runs the VOPRF protocol using p as input x to obtain output y.
-By construction, y will be the signature of p hashed onto the curve. C can then
+By construction, y will be the OPRF evaluation of p hashed onto the curve. C can then
 search D' for y to determine if there is a match.
 
 Examples of such password checkers already exist, for example: {{JKKX16}},


### PR DESCRIPTION
Fixes #34:
- Replace signing terminology to avoid confusion with asymmetric primitives
- Replace OPRF_Sign with OPRF_Eval